### PR TITLE
Fix behavior when no start directory given

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var
   fs              = require('fs'),
+  process         = require('process'),
   path            = require('path')
 ;
 
@@ -36,7 +37,7 @@ module.exports = function(file, directory, maxSteps) {
   };
 
   // start walk from outside require-dot-files directory
-  directory = directory || path.join(__dirname, path.sep , '..');
+  directory = directory || process.cwd();
   walk(directory);
 
   if(!requirePath) {


### PR DESCRIPTION
According to the readme if no start directory is given
then it will start searching from the current directory.
This was not the case since it started searching from the
parent directory where the `require-dot-file` resides. This
breaks in `semantic-ui` when `require-dot-file` is installed
non locally either globally or via the `nix` package manager.